### PR TITLE
Fix recv() method to correctly shift the 9 bits into the 16-bit buffer

### DIFF
--- a/src/SoftwareSerial9.cpp
+++ b/src/SoftwareSerial9.cpp
@@ -161,8 +161,11 @@ void SoftwareSerial9::recv()
       d >>= 1;
       DebugPulse(_DEBUG_PIN2, 1);
       if (rx_pin_read())
-        d |= 0x80;
+        d |= 0x8000;
     }
+	
+	// Shift in the remaining 7 bits to make up 16
+	d >>= 7;
 
     if (_inverse_logic)
       d = ~d;


### PR DESCRIPTION
Receiving 9-bit serial data packets returned an 8-bit (byte) result with the bits shifted right one too many times. The reason was that the received bits was shifted in from bit 7 instead of from bit 15.